### PR TITLE
Bu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:buster
 MAINTAINER AfterLogic Support <dockerimages@j3n50m4t.com>
 
 # installing packages and dependencies


### PR DESCRIPTION
change to buster because buster is the new stable debian version and therefore should be used for new projects